### PR TITLE
Add buildkite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The plugin can be used with the following CI providers:
 * Github Actions
 * Jenkins
 * Codeship
+* Buildkite
 
 
 ### Travis
@@ -131,3 +132,7 @@ jobs:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: ./gradlew test jacocoTestReport coverallsJacoco
 ```
+
+### Buildkite
+
+See [buildkite environment variables documentation](https://buildkite.com/docs/pipelines/environment-variables#defining-your-own)

--- a/src/main/kotlin/CoverallsReporter.kt
+++ b/src/main/kotlin/CoverallsReporter.kt
@@ -15,6 +15,7 @@ data class Request(
     val repo_token: String,
     val service_name: String,
     val service_job_id: String?,
+    val service_number: String?,
     val service_pull_request: String?,
     val git: GitInfo?,
     val source_files: List<SourceReport>
@@ -51,6 +52,7 @@ class CoverallsReporter(val envGetter: EnvGetter) {
         val req = Request(
                 repoToken,
                 serviceInfo.name,
+                serviceInfo.number,
                 serviceInfo.jobId,
                 serviceInfo.pr,
                 gitInfo,

--- a/src/main/kotlin/CoverallsReporter.kt
+++ b/src/main/kotlin/CoverallsReporter.kt
@@ -14,8 +14,8 @@ import org.gradle.api.Project
 data class Request(
     val repo_token: String,
     val service_name: String,
-    val service_job_id: String?,
     val service_number: String?,
+    val service_job_id: String?,
     val service_pull_request: String?,
     val git: GitInfo?,
     val source_files: List<SourceReport>

--- a/src/test/kotlin/DataClassTest.kt
+++ b/src/test/kotlin/DataClassTest.kt
@@ -37,10 +37,10 @@ internal class DataClassTest {
 
     @Test
     fun `data class ServiceInfo`() {
-        val svcInfo = ServiceInfo("1", "2", "job number", "3", "4")
+        val svcInfo = ServiceInfo("1", "job number", "2", "3", "4")
         assertEquals("1", svcInfo.name)
-        assertEquals("2", svcInfo.jobId)
         assertEquals("job number", svcInfo.number)
+        assertEquals("2", svcInfo.jobId)
         assertEquals("3", svcInfo.pr)
         assertEquals("4", svcInfo.branch)
     }

--- a/src/test/kotlin/DataClassTest.kt
+++ b/src/test/kotlin/DataClassTest.kt
@@ -37,9 +37,10 @@ internal class DataClassTest {
 
     @Test
     fun `data class ServiceInfo`() {
-        val svcInfo = ServiceInfo("1", "2", "3", "4")
+        val svcInfo = ServiceInfo("1", "2", "job number", "3", "4")
         assertEquals("1", svcInfo.name)
         assertEquals("2", svcInfo.jobId)
+        assertEquals("job number", svcInfo.number)
         assertEquals("3", svcInfo.pr)
         assertEquals("4", svcInfo.branch)
     }
@@ -65,9 +66,10 @@ internal class DataClassTest {
     fun `data class Request`() {
         val gitInfo = mockk<GitInfo>()
         val sourceFiles = emptyList<SourceReport>()
-        val req = Request("1", "2", "3", "4", gitInfo, sourceFiles)
+        val req = Request("1", "2", "job number", "3", "4", gitInfo, sourceFiles)
         assertEquals("1", req.repo_token)
         assertEquals("2", req.service_name)
+        assertEquals("job number", req.service_number)
         assertEquals("3", req.service_job_id)
         assertEquals("4", req.service_pull_request)
         assertEquals(gitInfo, req.git)

--- a/src/test/kotlin/ServiceInfoParserTest.kt
+++ b/src/test/kotlin/ServiceInfoParserTest.kt
@@ -14,7 +14,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("jenkins", "1", "123", "foobar")
+        val expected = ServiceInfo(name = "jenkins", jobId = "1", pr = "123", branch = "foobar")
         assertEquals(expected, actual)
     }
 
@@ -27,7 +27,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("jenkins", "1", null, "master")
+        val expected = ServiceInfo(name = "jenkins", jobId = "1", pr = null, branch = "master")
         assertEquals(expected, actual)
     }
 
@@ -42,7 +42,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("travis-ci", "1", "123", "foobar")
+        val expected = ServiceInfo(name = "travis-ci", jobId = "1", pr = "123", branch = "foobar")
         assertEquals(expected, actual)
     }
 
@@ -56,7 +56,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("travis-pro", "1", "123", "foobar")
+        val expected = ServiceInfo(name = "travis-pro", jobId = "1", pr = "123", branch = "foobar")
         assertEquals(expected, actual)
     }
 
@@ -69,7 +69,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("travis-pro", "1", null, "master")
+        val expected = ServiceInfo(name = "travis-pro", jobId = "1", pr = null, branch = "master")
         assertEquals(expected, actual)
     }
 
@@ -83,7 +83,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("circleci", "1", "123", "foobar")
+        val expected = ServiceInfo(name = "circleci", jobId = "1", pr = "123", branch = "foobar")
         assertEquals(expected, actual)
     }
 
@@ -96,7 +96,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("circleci", "1", null, "master")
+        val expected = ServiceInfo(name = "circleci", jobId = "1", pr = null, branch = "master")
         assertEquals(expected, actual)
     }
 
@@ -110,7 +110,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("codeship", "1", "123", "foobar")
+        val expected = ServiceInfo(name = "codeship", jobId = "1", pr = "123", branch = "foobar")
         assertEquals(expected, actual)
     }
 
@@ -123,7 +123,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("codeship", "1", null, "master")
+        val expected = ServiceInfo(name = "codeship", jobId = "1",pr = null, branch = "master")
         assertEquals(expected, actual)
     }
 
@@ -137,7 +137,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("github-actions", "1", "123", "foobar")
+        val expected = ServiceInfo(name = "github-actions", jobId = "1", pr = "123", branch = "foobar")
         assertEquals(expected, actual)
     }
 
@@ -150,7 +150,24 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo("github-actions", "1", null, "master")
+        val expected = ServiceInfo(name = "github-actions", jobId = "1", pr = null, branch = "master")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `ServiceInfoParser parses buildkite env`() {
+        val envGetter = createEnvGetter(mapOf(
+                "BUILDKITE" to "true",
+                "BUILDKITE_BUILD_NUMBER" to "123",
+                "BUILDKITE_BUILD_URL" to "https://buildkite.com/your-org/your-repo/builds/123",
+                "BUILDKITE_BUILD_ID" to "58b195c0-94aa-43ba-ae43-00b93c29a8b7",
+                "BUILDKITE_BRANCH" to "foobar",
+                "BUILDKITE_COMMIT" to "231asdfadsf424",
+                "BUILDKITE_PULL_REQUEST" to "11"
+        ))
+
+        val actual = ServiceInfoParser(envGetter).parse()
+        val expected = ServiceInfo(name = "buildkite", jobId = "58b195c0-94aa-43ba-ae43-00b93c29a8b7", number = "123", pr = "11", branch = "foobar")
         assertEquals(expected, actual)
     }
 

--- a/src/test/kotlin/ServiceInfoParserTest.kt
+++ b/src/test/kotlin/ServiceInfoParserTest.kt
@@ -167,7 +167,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo(name = "buildkite", jobId = "58b195c0-94aa-43ba-ae43-00b93c29a8b7", number = "123", pr = "11", branch = "foobar")
+        val expected = ServiceInfo(name = "buildkite", number = "123", jobId = "58b195c0-94aa-43ba-ae43-00b93c29a8b7", pr = "11", branch = "foobar")
         assertEquals(expected, actual)
     }
 


### PR DESCRIPTION
### Buildkite Support
Env variables obtained from:
- Buildkite documentation: 
- official coveralls npm package: https://github.com/nickmerwin/node-coveralls/blob/master/lib/getOptions.js#L109

### service_number support
- Add service number support.
- Only add impl for Buildkite use case, though I believe it should be adopted for consistency with JS builds.
- Checking against official coveralls npm package, it would appear that `service_job_id` is used inconsistently.