### PR TITLE
Add support for service_job_number, service_branch & service_build_url. …

### DIFF
--- a/src/main/kotlin/CoverallsReporter.kt
+++ b/src/main/kotlin/CoverallsReporter.kt
@@ -17,7 +17,10 @@ data class Request(
     val repo_name: String?,
     val service_number: String?,
     val service_job_id: String?,
+    val service_job_number: String?,
     val service_pull_request: String?,
+    val service_branch: String?,
+    val service_build_url: String?,
     val git: GitInfo?,
     val source_files: List<SourceReport>
 )
@@ -51,14 +54,17 @@ class CoverallsReporter(val envGetter: EnvGetter) {
         check(repoToken != null && repoToken.isNotBlank()) { "COVERALLS_REPO_TOKEN not set" }
 
         val req = Request(
-                repoToken,
-                serviceInfo.name,
-                serviceInfo.repoName,
-                serviceInfo.number,
-                serviceInfo.jobId,
-                serviceInfo.pr,
-                gitInfo,
-                sourceFiles
+                repo_token = repoToken,
+                repo_name = serviceInfo.repoName,
+                service_name = serviceInfo.name,
+                service_number = serviceInfo.number,
+                service_job_id = serviceInfo.jobId,
+                service_job_number = serviceInfo.jobNumber,
+                service_pull_request = serviceInfo.pr,
+                service_branch = serviceInfo.branch,
+                service_build_url = serviceInfo.buildUrl,
+                git = gitInfo,
+                source_files = sourceFiles
         )
 
         send(pluginExtension.apiEndpoint, req)

--- a/src/main/kotlin/ServiceInfoParser.kt
+++ b/src/main/kotlin/ServiceInfoParser.kt
@@ -30,6 +30,7 @@ class ServiceInfoParser(val envGetter: EnvGetter) {
             )
             isTravis -> ServiceInfo(
                     name = envGetter("CI_NAME") ?: "travis-pro",
+                    number = envGetter("TRAVIS_BUILD_NUMBER"),
                     jobId = envGetter("TRAVIS_JOB_ID"),
                     pr = envGetter("TRAVIS_PULL_REQUEST"),
                     branch = envGetter("TRAVIS_BRANCH")

--- a/src/main/kotlin/ServiceInfoParser.kt
+++ b/src/main/kotlin/ServiceInfoParser.kt
@@ -1,6 +1,15 @@
 package org.gradle.plugin.coveralls.jacoco
 
-data class ServiceInfo(val name: String, val repoName: String? = null, val number: String? = null, val jobId: String? = null, val pr: String? = null, val branch: String? = null)
+data class ServiceInfo(
+    val name: String,
+    val repoName: String? = null,
+    val number: String? = null,
+    val jobId: String? = null,
+    val jobNumber: String? = null,
+    val pr: String? = null,
+    val branch: String? = null,
+    val buildUrl: String? = null
+)
 
 class ServiceInfoParser(val envGetter: EnvGetter) {
     private val isJenkins = envGetter("JENKINS_URL") != null
@@ -27,7 +36,8 @@ class ServiceInfoParser(val envGetter: EnvGetter) {
             )
             isCircleCI -> ServiceInfo(
                     name = "circleci",
-                    jobId = envGetter("CIRCLE_BUILD_NUM"),
+                    number = envGetter("CIRCLE_WORKFLOW_ID"),
+                    jobNumber = envGetter("CIRCLE_BUILD_NUM"),
                     pr = envGetter("CIRCLE_PULL_REQUEST")?.substringAfterLast("/"),
                     branch = envGetter("CIRCLE_BRANCH")
             )
@@ -63,7 +73,8 @@ class ServiceInfoParser(val envGetter: EnvGetter) {
                     number = envGetter("BUILDKITE_BUILD_NUMBER"),
                     jobId = envGetter("BUILDKITE_BUILD_ID"),
                     pr = if (envGetter("BUILDKITE_PULL_REQUEST") == "false")  null else envGetter("BUILDKITE_PULL_REQUEST"),
-                    branch = envGetter("BUILDKITE_BRANCH")
+                    branch = envGetter("BUILDKITE_BRANCH"),
+                    buildUrl = envGetter("BUILDKITE_BUILD_URL")
             )
             else -> ServiceInfo("other")
         }

--- a/src/test/kotlin/DataClassTest.kt
+++ b/src/test/kotlin/DataClassTest.kt
@@ -37,13 +37,15 @@ internal class DataClassTest {
 
     @Test
     fun `data class ServiceInfo`() {
-        val svcInfo = ServiceInfo("name", "repo_name","number", "jobId", "pr", "branch")
+        val svcInfo = ServiceInfo("name", "repo_name","number", "jobId", "jobNumber", "pr", "branch", "buildNumber")
         assertEquals("name", svcInfo.name)
         assertEquals("repo_name", svcInfo.repoName)
         assertEquals("number", svcInfo.number)
         assertEquals("jobId", svcInfo.jobId)
+        assertEquals("jobNumber", svcInfo.jobNumber)
         assertEquals("pr", svcInfo.pr)
         assertEquals("branch", svcInfo.branch)
+        assertEquals("buildNumber", svcInfo.buildUrl)
     }
 
     @Test
@@ -72,7 +74,10 @@ internal class DataClassTest {
                 "repo_name",
                 "service_number",
                 "service_job_id",
+                "service_job_number",
                 "service_pull_request",
+                "service_branch",
+                "service_build_url",
                 gitInfo,
                 sourceFiles
         )
@@ -81,7 +86,10 @@ internal class DataClassTest {
         assertEquals("repo_name", req.repo_name)
         assertEquals("service_number", req.service_number)
         assertEquals("service_job_id", req.service_job_id)
+        assertEquals("service_job_number", req.service_job_number)
         assertEquals("service_pull_request", req.service_pull_request)
+        assertEquals("service_branch", req.service_branch)
+        assertEquals("service_build_url", req.service_build_url)
         assertEquals(gitInfo, req.git)
         assertEquals(sourceFiles, req.source_files)
     }

--- a/src/test/kotlin/ServiceInfoParserTest.kt
+++ b/src/test/kotlin/ServiceInfoParserTest.kt
@@ -77,13 +77,14 @@ internal class ServiceInfoParserTest {
     fun `ServiceInfoParser parses circleci env on pr`() {
         val envGetter = createEnvGetter(mapOf(
                 "CIRCLECI" to "true",
-                "CIRCLE_BUILD_NUM" to "1",
+                "CIRCLE_WORKFLOW_ID" to "1",
+                "CIRCLE_BUILD_NUM" to "2",
                 "CIRCLE_PULL_REQUEST" to "https://github.com/username/repo/pull/123",
                 "CIRCLE_BRANCH" to "foobar"
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo(name = "circleci", jobId = "1", pr = "123", branch = "foobar")
+        val expected = ServiceInfo(name = "circleci", number = "1", jobNumber = "2", pr = "123", branch = "foobar")
         assertEquals(expected, actual)
     }
 
@@ -91,12 +92,13 @@ internal class ServiceInfoParserTest {
     fun `ServiceInfoParser parses circleci env on master`() {
         val envGetter = createEnvGetter(mapOf(
                 "CIRCLECI" to "true",
-                "CIRCLE_BUILD_NUM" to "1",
+                "CIRCLE_WORKFLOW_ID" to "1",
+                "CIRCLE_BUILD_NUM" to "2",
                 "CIRCLE_BRANCH" to "master"
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo(name = "circleci", jobId = "1", pr = null, branch = "master")
+        val expected = ServiceInfo(name = "circleci", number = "1", jobNumber = "2", pr = null, branch = "master")
         assertEquals(expected, actual)
     }
 
@@ -183,7 +185,7 @@ internal class ServiceInfoParserTest {
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo(name = "buildkite", number = "123", jobId = "58b195c0-94aa-43ba-ae43-00b93c29a8b7", pr = "11", branch = "foobar")
+        val expected = ServiceInfo(name = "buildkite", number = "123", jobId = "58b195c0-94aa-43ba-ae43-00b93c29a8b7", pr = "11", branch = "foobar", buildUrl = "https://buildkite.com/your-org/your-repo/builds/123")
         assertEquals(expected, actual)
     }
 

--- a/src/test/kotlin/ServiceInfoParserTest.kt
+++ b/src/test/kotlin/ServiceInfoParserTest.kt
@@ -36,13 +36,14 @@ internal class ServiceInfoParserTest {
         val envGetter = createEnvGetter(mapOf(
                 "TRAVIS" to "true",
                 "CI_NAME" to "travis-ci",
-                "TRAVIS_JOB_ID" to "1",
+                "TRAVIS_BUILD_NUMBER" to "1",
+                "TRAVIS_JOB_ID" to "2",
                 "TRAVIS_PULL_REQUEST" to "123",
                 "TRAVIS_BRANCH" to "foobar"
         ))
 
         val actual = ServiceInfoParser(envGetter).parse()
-        val expected = ServiceInfo(name = "travis-ci", jobId = "1", pr = "123", branch = "foobar")
+        val expected = ServiceInfo(name = "travis-ci", number = "1", jobId = "2", pr = "123", branch = "foobar")
         assertEquals(expected, actual)
     }
 


### PR DESCRIPTION
…Also align CircleCI & Travis with node-coveralls.

See:
- https://github.com/nickmerwin/node-coveralls/pull/290
- https://github.com/nickmerwin/node-coveralls/blob/master/lib/getOptions.js#L25
- https://github.com/nickmerwin/node-coveralls/blob/master/lib/getOptions.js#L55

The variables `service_job_number`, `service_branch` & `service_build_url` have been confirmed to exist by coveralls support. They are as yet undocumented. Some are also in use in the various coveralls libs for node etc.

I have confirmed the service_build_url variable does render a link back to build on coveralls UI