### PR TITLE
Prevent ArrayIndexOutOfBounds crashes

### DIFF
--- a/src/main/kotlin/SourceReportParser.kt
+++ b/src/main/kotlin/SourceReportParser.kt
@@ -85,7 +85,11 @@ object SourceReportParser {
                         val lines = f.readLines()
                         val lineHits = arrayOfNulls<Int>(lines.size)
 
-                        cov.forEach { (line, hits) -> lineHits[line] = hits }
+                        cov.forEach { (line, hits) ->
+                            if (line < lineHits.size) {
+                                lineHits[line] = hits
+                            }
+                        }
 
                         val relPath = File(project.projectDir.absolutePath).toURI().relativize(f.toURI()).toString()
                         SourceReport(relPath, f.md5(), lineHits.toList())


### PR DESCRIPTION
This Pr fixes issue https://github.com/nbaztec/coveralls-jacoco-gradle-plugin/issues/20 where the jacoco test report and the source file did not have matching lines (maybe something with the kotlin compiler?)

By checking if the index exists before writing, we prevent the plugin from crashing