### PR TITLE
Break android build tools dependency with compileOnly and guard

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,9 @@ dependencies {
     implementation("org.eclipse.jgit", "org.eclipse.jgit", "5.8.1.202007141445-r")
     implementation("org.apache.httpcomponents", "httpmime", "4.5.12")
     implementation("com.google.code.gson", "gson", "2.8.5")
-    implementation("com.android.tools.build", "gradle", "4.0.1")
+    //only use this to find android sourceSets, so only need it at compile time not a runtime dependency
+    compileOnly("com.android.tools.build", "gradle", "4.0.1")
+    testImplementation("com.android.tools.build", "gradle", "4.0.1")
     testImplementation("junit", "junit", "4.13")
     testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.6.2")
     testRuntimeOnly("org.junit.jupiter", "junit-jupiter-engine", "5.6.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation("org.eclipse.jgit", "org.eclipse.jgit", "5.8.1.202007141445-r")
     implementation("org.apache.httpcomponents", "httpmime", "4.5.12")
     implementation("com.google.code.gson", "gson", "2.8.5")
-    //only use this to find android sourceSets, so only need it at compile time not a runtime dependency
     compileOnly("com.android.tools.build", "gradle", "4.0.1")
     testImplementation("com.android.tools.build", "gradle", "4.0.1")
     testImplementation("junit", "junit", "4.13")

--- a/src/test/kotlin/SourceReportParserTest.kt
+++ b/src/test/kotlin/SourceReportParserTest.kt
@@ -3,6 +3,7 @@ package org.gradle.plugin.coveralls.jacoco
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSetContainer
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -99,21 +100,23 @@ internal class SourceReportParserTest {
             }
         }
 
-        SourceReportParser.hasAndroidClasses = false
-        val actual = SourceReportParser.parse(project)
-        SourceReportParser.hasAndroidClasses = true
-        val expected = listOf(
-                SourceReport(
-                        "src/main/kotlin/Main.kt",
-                        "36083cd4c2ac736f9210fd3ed23504b5",
-                        listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
-                SourceReport(
-                        "src/main/kotlin/internal/Util.kt",
-                        "805ee340f4d661be591b4eb42f6164d2",
-                        listOf(null, null, null, null, 1, 1, 1, null, null)
-                )
-        )
-        assertEquals(expected, actual)
+        mockkObject(SourceReportParser, recordPrivateCalls = true) {
+            every { SourceReportParser getProperty "hasAndroid" } returns false
+
+            val actual = SourceReportParser.parse(project)
+            val expected = listOf(
+                    SourceReport(
+                            "src/main/kotlin/Main.kt",
+                            "36083cd4c2ac736f9210fd3ed23504b5",
+                            listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
+                    SourceReport(
+                            "src/main/kotlin/internal/Util.kt",
+                            "805ee340f4d661be591b4eb42f6164d2",
+                            listOf(null, null, null, null, 1, 1, 1, null, null)
+                    )
+            )
+            assertEquals(expected, actual)
+        }
     }
 
     @Test

--- a/src/test/kotlin/SourceReportParserTest.kt
+++ b/src/test/kotlin/SourceReportParserTest.kt
@@ -87,6 +87,36 @@ internal class SourceReportParserTest {
     }
 
     @Test
+    fun `SourceReportParser parses simple jacoco report without android classes`() {
+        val project = mockk<Project> {
+            every { projectDir } returns File("src/test/resources/testrepo")
+            every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
+                every { getByName("main").allJava.srcDirs } returns setOf(testKotlinStyleSourceDir)
+            }
+            every { extensions.getByType(CoverallsJacocoPluginExtension::class.java) } returns mockk {
+                every { reportPath } returns testReport.path
+                every { reportSourceSets } returns emptySet()
+            }
+        }
+
+        SourceReportParser.hasAndroidClasses = false
+        val actual = SourceReportParser.parse(project)
+        SourceReportParser.hasAndroidClasses = true
+        val expected = listOf(
+                SourceReport(
+                        "src/main/kotlin/Main.kt",
+                        "36083cd4c2ac736f9210fd3ed23504b5",
+                        listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
+                SourceReport(
+                        "src/main/kotlin/internal/Util.kt",
+                        "805ee340f4d661be591b4eb42f6164d2",
+                        listOf(null, null, null, null, 1, 1, 1, null, null)
+                )
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `SourceReportParser parses simple jacoco report with kotlin styled root package`() {
         val project = mockk<Project> {
             every { projectDir } returns File("src/test/resources/testrepo")


### PR DESCRIPTION
Reduces the number of deps that users of the plugin need