### PR TITLE
Reapply "Break android build tools dependency with compileOnly and guard" with fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ The plugin automatically detects the root package, if it conforms to Kotlin guid
 
 [Gradle Plugin page](https://plugins.gradle.org/plugin/com.github.nbaztec.coveralls-jacoco)
 
-Add the `google()` repository. The plugin relies on it to detect android projects.
-Apply the plugin with the ID: `com.github.nbaztec.coveralls-jacoco`.
+Apply the plugin with the ID: `com.github.nbaztec.coveralls-jacoco`. 
 
 ```kotlin
 // build.gradle.kts
 
 buildscript {
     repositories {
-        google()
         mavenCentral()
         jcenter()
     }
@@ -28,7 +26,7 @@ buildscript {
 
 plugins {
     jacoco
-    id("com.github.nbaztec.coveralls-jacoco") version "1.2.8"
+    id("com.github.nbaztec.coveralls-jacoco") version "1.2.7"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ buildscript {
 
 plugins {
     jacoco
-    id("com.github.nbaztec.coveralls-jacoco") version "1.2.7"
+    id("com.github.nbaztec.coveralls-jacoco") version "1.2.9"
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,18 +38,12 @@ val testAndroidMain: SourceSet by sourceSets.creating {
     runtimeClasspath += sourceSets.main.get().output
 }
 
-configurations {
-    val testAndroidMainImplementation: Configuration by getting {
-        extendsFrom(testImplementation.get())
+val testAndroidMainImplementation: Configuration by configurations.getting {
+    extendsFrom(configurations.implementation.get())
+}
 
-        dependencies {
-            testImplementation("com.android.tools.build", "gradle", "4.0.1")
-        }
-    }
-
-    val testAndroidMainRuntimeOnly: Configuration by getting {
-        extendsFrom(testRuntimeOnly.get())
-    }
+val testAndroidMainRuntimeOnly: Configuration by configurations.getting {
+    extendsFrom(configurations.runtimeOnly.get())
 }
 
 dependencies {
@@ -66,6 +60,12 @@ dependencies {
     testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.7.0")
     testImplementation("io.mockk", "mockk", "1.10.5")
     testRuntimeOnly("org.junit.jupiter", "junit-jupiter-engine", "5.7.0")
+
+    testAndroidMainImplementation("com.android.tools.build", "gradle", "4.0.1")
+    testAndroidMainImplementation("junit", "junit", "4.13.1")
+    testAndroidMainImplementation("org.junit.jupiter", "junit-jupiter-api", "5.7.0")
+    testAndroidMainImplementation("io.mockk", "mockk", "1.10.5")
+    testAndroidMainRuntimeOnly("org.junit.jupiter", "junit-jupiter-engine", "5.7.0")
 }
 
 tasks {
@@ -75,7 +75,7 @@ tasks {
 
     val testAndroid by registering(Test::class) {
         useJUnitPlatform()
-        description = "Runs android tests."
+        description = "Runs android source set tests."
         group = "verification"
         testClassesDirs = testAndroidMain.output.classesDirs
         classpath = testAndroidMain.runtimeClasspath

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,7 @@ tasks {
             xml.isEnabled = true
             html.isEnabled = true
         }
+        executionData(testAndroid)
     }
 
     create("setupPublishSecrets") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "com.github.nbaztec"
-version = "1.2.7"
+version = "1.2.9"
 
 buildscript {
     repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "com.github.nbaztec"
-version = "1.2.8"
+version = "1.2.7"
 
 buildscript {
     repositories {
@@ -36,7 +36,8 @@ dependencies {
     implementation("org.eclipse.jgit", "org.eclipse.jgit", "5.8.1.202007141445-r")
     implementation("org.apache.httpcomponents", "httpmime", "4.5.12")
     implementation("com.google.code.gson", "gson", "2.8.5")
-    implementation("com.android.tools.build", "gradle", "4.0.1")
+    compileOnly("com.android.tools.build", "gradle", "4.0.1")
+    testImplementation("com.android.tools.build", "gradle", "4.0.1")
     testImplementation("junit", "junit", "4.13")
     testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.6.2")
     testRuntimeOnly("org.junit.jupiter", "junit-jupiter-engine", "5.6.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ tasks {
             xml.isEnabled = true
             html.isEnabled = true
         }
-        executionData(testAndroid)
+        executionData(File(buildDir, "jacoco/testAndroid.exec"))
     }
 
     create("setupPublishSecrets") {

--- a/src/main/kotlin/SourceReportParser.kt
+++ b/src/main/kotlin/SourceReportParser.kt
@@ -10,15 +10,15 @@ import java.io.File
 import java.math.BigInteger
 import java.security.MessageDigest
 
-
 data class SourceReport(val name: String, val source_digest: String, val coverage: List<Int?>)
 
 data class Key(val pkg: String, val file: String)
 
 object SourceReportParser {
     private val logger: Logger by lazy { LogManager.getLogger(CoverallsReporter::class.java) }
+
     //test to see if we have the required android classes, use this to guard the android source set lookup
-    private val hasAndroid by lazy {
+    private val hasAndroidExtension by lazy {
         try {
             Class.forName("com.android.build.gradle.internal.dsl.BaseAppModuleExtension")
             true
@@ -69,17 +69,13 @@ object SourceReportParser {
         val pluginExtension = project.extensions.getByType(CoverallsJacocoPluginExtension::class.java)
 
         val sourceDirs = if (pluginExtension.reportSourceSets.count() == 0) {
-            if (hasAndroid) {
-                val androidExtension = project.extensions.findByType(BaseAppModuleExtension::class.java)
-                androidExtension?.let {
-                    androidExtension.sourceSets.getByName("main").java.srcDirs.filterNotNull()
-                } ?: project.extensions.getByType(SourceSetContainer::class.java)
-                        .getByName("main").allJava.srcDirs.filterNotNull()
+            if (hasAndroidExtension) {
+                project.extensions.findByType(BaseAppModuleExtension::class.java)!!.sourceSets
+                    .getByName("main").java.srcDirs.filterNotNull()
             } else {
                 project.extensions.getByType(SourceSetContainer::class.java)
-                        .getByName("main").allJava.srcDirs.filterNotNull()
+                    .getByName("main").allJava.srcDirs.filterNotNull()
             }
-
         } else {
             pluginExtension.reportSourceSets.toList()
         }
@@ -92,27 +88,27 @@ object SourceReportParser {
 
         logger.info("using source directories: $sourceDirs")
         return read(pluginExtension.reportPath)
-                .mapNotNull { (key, cov) ->
-                    fileFinder.find(File(key.pkg, key.file))?.let { f ->
-                        logger.debug("found file: $f")
+            .mapNotNull { (key, cov) ->
+                fileFinder.find(File(key.pkg, key.file))?.let { f ->
+                    logger.debug("found file: $f")
 
-                        val lines = f.readLines()
-                        val lineHits = arrayOfNulls<Int>(lines.size)
+                    val lines = f.readLines()
+                    val lineHits = arrayOfNulls<Int>(lines.size)
 
-                        cov.forEach { (line, hits) ->
-                            if (line < lines.size) {
-                                lineHits[line] = hits
-                            } else {
-                                logger.debug("skipping invalid line $line, (total ${lines.size})")
-                            }
+                    cov.forEach { (line, hits) ->
+                        if (line < lines.size) {
+                            lineHits[line] = hits
+                        } else {
+                            logger.debug("skipping invalid line $line, (total ${lines.size})")
                         }
-
-                        val relPath = File(project.projectDir.absolutePath).toURI().relativize(f.toURI()).toString()
-                        SourceReport(relPath, f.md5(), lineHits.toList())
-                    }.also {
-                        it
-                                ?: logger.info("${key.file} could not be found in any of the source directories, skipping")
                     }
+
+                    val relPath = File(project.projectDir.absolutePath).toURI().relativize(f.toURI()).toString()
+                    SourceReport(relPath, f.md5(), lineHits.toList())
+                }.also {
+                    it
+                        ?: logger.info("${key.file} could not be found in any of the source directories, skipping")
                 }
+            }
     }
 }

--- a/src/main/kotlin/SourceReportParser.kt
+++ b/src/main/kotlin/SourceReportParser.kt
@@ -22,7 +22,7 @@ object SourceReportParser {
         try {
             Class.forName("com.android.build.gradle.internal.dsl.BaseAppModuleExtension")
             true
-        } catch (e: NoClassDefFoundError) {
+        } catch (e: ClassNotFoundException) {
             false
         }
     }

--- a/src/test/kotlin/CoverallsReporterTest.kt
+++ b/src/test/kotlin/CoverallsReporterTest.kt
@@ -1,12 +1,8 @@
 package org.gradle.plugin.coveralls.jacoco
 
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
-import com.google.gson.Gson
 import com.sun.net.httpserver.HttpServer
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verifyAll
 import kotlinx.coroutines.GlobalScope
@@ -245,7 +241,6 @@ Content-Transfer-Encoding: binary
 
         val project = mockk<Project> {
             every { projectDir } returns testRepo
-            every { extensions.findByType(BaseAppModuleExtension::class.java) } returns null
             every { extensions.getByType(SourceSetContainer::class.java) } returns sourceSetContainer
             every { extensions.getByType(CoverallsJacocoPluginExtension::class.java) } returns pluginExtension
         }

--- a/src/test/kotlin/SourceReportParserTest.kt
+++ b/src/test/kotlin/SourceReportParserTest.kt
@@ -1,6 +1,5 @@
 package org.gradle.plugin.coveralls.jacoco
 
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -21,7 +20,6 @@ internal class SourceReportParserTest {
     fun `SourceReportParser parses skips parsing if source directories empty`() {
         val project = mockk<Project> {
             every { projectDir } returns File("src/test/resources/testrepo")
-            every { extensions.findByType(BaseAppModuleExtension::class.java) } returns null
             every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
                 every { getByName("main").allJava.srcDirs } returns emptySet()
             }
@@ -39,7 +37,6 @@ internal class SourceReportParserTest {
     fun `SourceReportParser parses simple jacoco report with java styled package`() {
         val project = mockk<Project> {
             every { projectDir } returns File("src/test/resources/testrepo")
-            every { extensions.findByType(BaseAppModuleExtension::class.java) } returns null
             every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
                 every { getByName("main").allJava.srcDirs } returns setOf(testJavaStyleSourceDir)
             }
@@ -63,8 +60,8 @@ internal class SourceReportParserTest {
     fun `SourceReportParser parses simple android jacoco report with kotlin styled root package`() {
         val project = mockk<Project> {
             every { projectDir } returns File("src/test/resources/testrepo")
-            every { extensions.findByType(BaseAppModuleExtension::class.java) } returns mockk {
-                every { sourceSets.getByName("main").java.srcDirs } returns setOf(testKotlinStyleSourceDir)
+            every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
+                every { getByName("main").allJava.srcDirs } returns setOf(testKotlinStyleSourceDir)
             }
             every { extensions.getByType(CoverallsJacocoPluginExtension::class.java) } returns mockk {
                 every { reportPath } returns testReport.path
@@ -100,23 +97,19 @@ internal class SourceReportParserTest {
             }
         }
 
-        mockkObject(SourceReportParser, recordPrivateCalls = true) {
-            every { SourceReportParser getProperty "hasAndroid" } returns false
-
-            val actual = SourceReportParser.parse(project)
-            val expected = listOf(
-                    SourceReport(
-                            "src/main/kotlin/Main.kt",
-                            "36083cd4c2ac736f9210fd3ed23504b5",
-                            listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
-                    SourceReport(
-                            "src/main/kotlin/internal/Util.kt",
-                            "805ee340f4d661be591b4eb42f6164d2",
-                            listOf(null, null, null, null, 1, 1, 1, null, null)
-                    )
+        val actual = SourceReportParser.parse(project)
+        val expected = listOf(
+            SourceReport(
+                "src/main/kotlin/Main.kt",
+                "36083cd4c2ac736f9210fd3ed23504b5",
+                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
+            SourceReport(
+                "src/main/kotlin/internal/Util.kt",
+                "805ee340f4d661be591b4eb42f6164d2",
+                listOf(null, null, null, null, 1, 1, 1, null, null)
             )
-            assertEquals(expected, actual)
-        }
+        )
+        assertEquals(expected, actual)
     }
 
     @Test
@@ -126,7 +119,6 @@ internal class SourceReportParserTest {
             every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
                 every { getByName("main").allJava.srcDirs } returns setOf(testKotlinStyleSourceDir)
             }
-            every { extensions.findByType(BaseAppModuleExtension::class.java) } returns null
             every { extensions.getByType(CoverallsJacocoPluginExtension::class.java) } returns mockk {
                 every { reportPath } returns testReport.path
                 every { reportSourceSets } returns emptySet()

--- a/src/test/kotlin/SourceReportParserTest.kt
+++ b/src/test/kotlin/SourceReportParserTest.kt
@@ -2,7 +2,6 @@ package org.gradle.plugin.coveralls.jacoco
 
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSetContainer
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -48,10 +47,11 @@ internal class SourceReportParserTest {
 
         val actual = SourceReportParser.parse(project)
         val expected = listOf(
-                SourceReport(
-                        "javaStyleSrc/main/kotlin/foo/bar/baz/Main.kt",
-                        "36083cd4c2ac736f9210fd3ed23504b5",
-                        listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1))
+            SourceReport(
+                "javaStyleSrc/main/kotlin/foo/bar/baz/Main.kt",
+                "36083cd4c2ac736f9210fd3ed23504b5",
+                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)
+            )
         )
         assertEquals(expected, actual)
     }
@@ -71,15 +71,16 @@ internal class SourceReportParserTest {
 
         val actual = SourceReportParser.parse(project)
         val expected = listOf(
-                SourceReport(
-                        "src/main/kotlin/Main.kt",
-                        "36083cd4c2ac736f9210fd3ed23504b5",
-                        listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
-                SourceReport(
-                        "src/main/kotlin/internal/Util.kt",
-                        "805ee340f4d661be591b4eb42f6164d2",
-                        listOf(null, null, null, null, 1, 1, 1, null, null)
-                )
+            SourceReport(
+                "src/main/kotlin/Main.kt",
+                "36083cd4c2ac736f9210fd3ed23504b5",
+                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)
+            ),
+            SourceReport(
+                "src/main/kotlin/internal/Util.kt",
+                "805ee340f4d661be591b4eb42f6164d2",
+                listOf(null, null, null, null, 1, 1, 1, null, null)
+            )
         )
         assertEquals(expected, actual)
     }
@@ -102,7 +103,8 @@ internal class SourceReportParserTest {
             SourceReport(
                 "src/main/kotlin/Main.kt",
                 "36083cd4c2ac736f9210fd3ed23504b5",
-                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
+                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)
+            ),
             SourceReport(
                 "src/main/kotlin/internal/Util.kt",
                 "805ee340f4d661be591b4eb42f6164d2",
@@ -127,15 +129,16 @@ internal class SourceReportParserTest {
 
         val actual = SourceReportParser.parse(project)
         val expected = listOf(
-                SourceReport(
-                        "src/main/kotlin/Main.kt",
-                        "36083cd4c2ac736f9210fd3ed23504b5",
-                        listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
-                SourceReport(
-                        "src/main/kotlin/internal/Util.kt",
-                        "805ee340f4d661be591b4eb42f6164d2",
-                        listOf(null, null, null, null, 1, 1, 1, null, null)
-                )
+            SourceReport(
+                "src/main/kotlin/Main.kt",
+                "36083cd4c2ac736f9210fd3ed23504b5",
+                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)
+            ),
+            SourceReport(
+                "src/main/kotlin/internal/Util.kt",
+                "805ee340f4d661be591b4eb42f6164d2",
+                listOf(null, null, null, null, 1, 1, 1, null, null)
+            )
         )
         assertEquals(expected, actual)
     }
@@ -147,28 +150,29 @@ internal class SourceReportParserTest {
             every { extensions.getByType(CoverallsJacocoPluginExtension::class.java) } returns mockk {
                 every { reportPath } returns testReport.path
                 every { reportSourceSets } returns listOf(
-                        testKotlinStyleSourceDir,
-                        testKotlinStyleSourceDirAdditional
+                    testKotlinStyleSourceDir,
+                    testKotlinStyleSourceDirAdditional
                 )
             }
         }
 
         val actual = SourceReportParser.parse(project)
         val expected = listOf(
-                SourceReport(
-                        "src/main/kotlin/Main.kt",
-                        "36083cd4c2ac736f9210fd3ed23504b5",
-                        listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
-                SourceReport(
-                        "src/main/kotlin/internal/Util.kt",
-                        "805ee340f4d661be591b4eb42f6164d2",
-                        listOf(null, null, null, null, 1, 1, 1, null, null)
-                ),
-                SourceReport(
-                        "src/anotherMain/kotlin/Lib.kt",
-                        "8b5c1c773cf81996efc19a08f0ac3648",
-                        listOf(null, null, null, null, 1, 1, 1, null, null, null, null, null, null)
-                )
+            SourceReport(
+                "src/main/kotlin/Main.kt",
+                "36083cd4c2ac736f9210fd3ed23504b5",
+                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)
+            ),
+            SourceReport(
+                "src/main/kotlin/internal/Util.kt",
+                "805ee340f4d661be591b4eb42f6164d2",
+                listOf(null, null, null, null, 1, 1, 1, null, null)
+            ),
+            SourceReport(
+                "src/anotherMain/kotlin/Lib.kt",
+                "8b5c1c773cf81996efc19a08f0ac3648",
+                listOf(null, null, null, null, 1, 1, 1, null, null, null, null, null, null)
+            )
         )
         assertEquals(expected, actual)
     }
@@ -180,28 +184,29 @@ internal class SourceReportParserTest {
             every { extensions.getByType(CoverallsJacocoPluginExtension::class.java) } returns mockk {
                 every { reportPath } returns testReportMissingLines.path
                 every { reportSourceSets } returns listOf(
-                        testKotlinStyleSourceDir,
-                        testKotlinStyleSourceDirAdditional
+                    testKotlinStyleSourceDir,
+                    testKotlinStyleSourceDirAdditional
                 )
             }
         }
 
         val actual = SourceReportParser.parse(project)
         val expected = listOf(
-                SourceReport(
-                        "src/main/kotlin/Main.kt",
-                        "36083cd4c2ac736f9210fd3ed23504b5",
-                        listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
-                SourceReport(
-                        "src/main/kotlin/internal/Util.kt",
-                        "805ee340f4d661be591b4eb42f6164d2",
-                        listOf(null, null, null, null, 1, 1, 1, null, null)
-                ),
-                SourceReport(
-                        "src/anotherMain/kotlin/Lib.kt",
-                        "8b5c1c773cf81996efc19a08f0ac3648",
-                        listOf(null, null, null, null, 1, 1, 1, null, null, null, null, null, null)
-                )
+            SourceReport(
+                "src/main/kotlin/Main.kt",
+                "36083cd4c2ac736f9210fd3ed23504b5",
+                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)
+            ),
+            SourceReport(
+                "src/main/kotlin/internal/Util.kt",
+                "805ee340f4d661be591b4eb42f6164d2",
+                listOf(null, null, null, null, 1, 1, 1, null, null)
+            ),
+            SourceReport(
+                "src/anotherMain/kotlin/Lib.kt",
+                "8b5c1c773cf81996efc19a08f0ac3648",
+                listOf(null, null, null, null, 1, 1, 1, null, null, null, null, null, null)
+            )
         )
         assertEquals(expected, actual)
     }

--- a/src/testAndroid/kotlin/SourceReportParserTest.kt
+++ b/src/testAndroid/kotlin/SourceReportParserTest.kt
@@ -3,9 +3,7 @@ package org.gradle.plugin.coveralls.jacoco.androidTest
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import org.gradle.api.Project
-import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.plugin.coveralls.jacoco.CoverallsJacocoPluginExtension
 import org.gradle.plugin.coveralls.jacoco.SourceReport
 import org.gradle.plugin.coveralls.jacoco.SourceReportParser
@@ -16,16 +14,11 @@ import java.io.File
 internal class SourceReportParserTest {
     private val testReport = File("src/test/resources/testreports/jacocoTestReport.xml")
     private val testKotlinStyleSourceDir = File("src/test/resources/testrepo/src/main/kotlin")
-    private val testKotlinStyleSourceDirAdditional = File("src/test/resources/testrepo/src/anotherMain/kotlin")
-    private val testJavaStyleSourceDir = File("src/test/resources/testrepo/javaStyleSrc/main/kotlin")
 
     @Test
     fun `SourceReportParser parses simple jacoco report with android classes`() {
         val project = mockk<Project> {
             every { projectDir } returns File("src/test/resources/testrepo")
-            every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
-                every { getByName("main").allJava.srcDirs } returns setOf(testKotlinStyleSourceDir)
-            }
             every { extensions.findByType(BaseAppModuleExtension::class.java) } returns mockk {
                 every { sourceSets.getByName("main").java.srcDirs } returns setOf(testKotlinStyleSourceDir)
             }
@@ -40,7 +33,8 @@ internal class SourceReportParserTest {
             SourceReport(
                 "src/main/kotlin/Main.kt",
                 "36083cd4c2ac736f9210fd3ed23504b5",
-                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)),
+                listOf(null, null, null, null, 1, 1, 1, 1, null, 1, 1, 0, 0, 1, 1, null, 1, 1, 1)
+            ),
             SourceReport(
                 "src/main/kotlin/internal/Util.kt",
                 "805ee340f4d661be591b4eb42f6164d2",


### PR DESCRIPTION
Reverts nbaztec/coveralls-jacoco-gradle-plugin#33 and applies a fix for #31 