### PR TITLE
Switch to using rootDir from projectDir

### DIFF
--- a/src/main/kotlin/CoverallsReporter.kt
+++ b/src/main/kotlin/CoverallsReporter.kt
@@ -40,7 +40,7 @@ class CoverallsReporter(val envGetter: EnvGetter) {
         val pluginExtension = project.extensions.getByType(CoverallsJacocoPluginExtension::class.java)
 
         logger.info("retrieving git info")
-        val gitInfo = GitInfoParser.parse(project.projectDir)
+        val gitInfo = GitInfoParser.parse(project.rootDir)
 
         logger.info("parsing source files")
         val sourceFiles = SourceReportParser.parse(project)

--- a/src/main/kotlin/SourceReportParser.kt
+++ b/src/main/kotlin/SourceReportParser.kt
@@ -103,7 +103,7 @@ object SourceReportParser {
                         }
                     }
 
-                    val relPath = File(project.projectDir.absolutePath).toURI().relativize(f.toURI()).toString()
+                    val relPath = File(project.rootDir.absolutePath).toURI().relativize(f.toURI()).toString()
                     SourceReport(relPath, f.md5(), lineHits.toList())
                 }.also {
                     it

--- a/src/test/kotlin/CoverallsReporterTest.kt
+++ b/src/test/kotlin/CoverallsReporterTest.kt
@@ -240,7 +240,7 @@ Content-Transfer-Encoding: binary
         }
 
         val project = mockk<Project> {
-            every { projectDir } returns testRepo
+            every { rootDir } returns testRepo
             every { extensions.getByType(SourceSetContainer::class.java) } returns sourceSetContainer
             every { extensions.getByType(CoverallsJacocoPluginExtension::class.java) } returns pluginExtension
         }

--- a/src/test/kotlin/SourceReportParserTest.kt
+++ b/src/test/kotlin/SourceReportParserTest.kt
@@ -18,7 +18,7 @@ internal class SourceReportParserTest {
     @Test
     fun `SourceReportParser parses skips parsing if source directories empty`() {
         val project = mockk<Project> {
-            every { projectDir } returns File("src/test/resources/testrepo")
+            every { rootDir } returns File("src/test/resources/testrepo")
             every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
                 every { getByName("main").allJava.srcDirs } returns emptySet()
             }
@@ -35,7 +35,7 @@ internal class SourceReportParserTest {
     @Test
     fun `SourceReportParser parses simple jacoco report with java styled package`() {
         val project = mockk<Project> {
-            every { projectDir } returns File("src/test/resources/testrepo")
+            every { rootDir } returns File("src/test/resources/testrepo")
             every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
                 every { getByName("main").allJava.srcDirs } returns setOf(testJavaStyleSourceDir)
             }
@@ -59,7 +59,7 @@ internal class SourceReportParserTest {
     @Test
     fun `SourceReportParser parses simple android jacoco report with kotlin styled root package`() {
         val project = mockk<Project> {
-            every { projectDir } returns File("src/test/resources/testrepo")
+            every { rootDir } returns File("src/test/resources/testrepo")
             every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
                 every { getByName("main").allJava.srcDirs } returns setOf(testKotlinStyleSourceDir)
             }
@@ -88,7 +88,7 @@ internal class SourceReportParserTest {
     @Test
     fun `SourceReportParser parses simple jacoco report without android classes`() {
         val project = mockk<Project> {
-            every { projectDir } returns File("src/test/resources/testrepo")
+            every { rootDir } returns File("src/test/resources/testrepo")
             every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
                 every { getByName("main").allJava.srcDirs } returns setOf(testKotlinStyleSourceDir)
             }
@@ -117,7 +117,7 @@ internal class SourceReportParserTest {
     @Test
     fun `SourceReportParser parses simple jacoco report with kotlin styled root package`() {
         val project = mockk<Project> {
-            every { projectDir } returns File("src/test/resources/testrepo")
+            every { rootDir } returns File("src/test/resources/testrepo")
             every { extensions.getByType(SourceSetContainer::class.java) } returns mockk {
                 every { getByName("main").allJava.srcDirs } returns setOf(testKotlinStyleSourceDir)
             }
@@ -146,7 +146,7 @@ internal class SourceReportParserTest {
     @Test
     fun `SourceReportParser uses report source sets and parses jacoco report`() {
         val project = mockk<Project> {
-            every { projectDir } returns File("src/test/resources/testrepo")
+            every { rootDir } returns File("src/test/resources/testrepo")
             every { extensions.getByType(CoverallsJacocoPluginExtension::class.java) } returns mockk {
                 every { reportPath } returns testReport.path
                 every { reportSourceSets } returns listOf(
@@ -180,7 +180,7 @@ internal class SourceReportParserTest {
     @Test
     fun `SourceReportParser ignores lines in report that are missing in source`() {
         val project = mockk<Project> {
-            every { projectDir } returns File("src/test/resources/testrepo")
+            every { rootDir } returns File("src/test/resources/testrepo")
             every { extensions.getByType(CoverallsJacocoPluginExtension::class.java) } returns mockk {
                 every { reportPath } returns testReportMissingLines.path
                 every { reportSourceSets } returns listOf(

--- a/src/testAndroid/kotlin/SourceReportParserTest.kt
+++ b/src/testAndroid/kotlin/SourceReportParserTest.kt
@@ -18,7 +18,7 @@ internal class SourceReportParserTest {
     @Test
     fun `SourceReportParser parses simple jacoco report with android classes`() {
         val project = mockk<Project> {
-            every { projectDir } returns File("src/test/resources/testrepo")
+            every { rootDir } returns File("src/test/resources/testrepo")
             every { extensions.findByType(BaseAppModuleExtension::class.java) } returns mockk {
                 every { sourceSets.getByName("main").java.srcDirs } returns setOf(testKotlinStyleSourceDir)
             }


### PR DESCRIPTION
Fixes #50.  This seems to work in my local testing without regressing functionality, but I'm not 100% sure about it.