### PR TITLE
update dom4j and gson deps

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,10 +2,10 @@ object Versions {
     const val kotlin = "1.8.22"
     const val kotlinxCoroutines = "1.4.2"
 
-    const val dom4j = "2.1.1"
+    const val dom4j = "2.1.4"
     const val jgit = "5.10.0.202012080955-r"
     const val httpMime = "4.5.13"
-    const val gson = "2.8.6"
+    const val gson = "2.10.1"
     const val androidBuildTools = "4.0.1"
 
     const val junit = "4.13.1"


### PR DESCRIPTION
Updates the dependencies to:

* `dom4j:2.1.4` 
* `gson:2.10.1`

Fixes #63 